### PR TITLE
refactor: update token naming in code to match README

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -31,7 +31,7 @@ type deleteCmd struct {
 }
 
 func (d *deleteCmd) Run(kongCtx *kong.Context) error {
-	objectStoreClient := objectStoreClient(d.BaseURL, d.LatticeVMToken, d.LatticeEnvToken, nil)
+	objectStoreClient := objectStoreClient(d.BaseURL, d.EnvironmentToken, d.SandboxesToken, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -65,8 +65,8 @@ func (u *uploadCmd) Run(kongCtx *kong.Context) error {
 
 	objectStoreClient := objectStoreClient(
 		u.BaseURL,
-		u.LatticeVMToken,
-		u.LatticeEnvToken,
+		u.EnvironmentToken,
+		u.SandboxesToken,
 		ttlHeader,
 	)
 
@@ -101,7 +101,7 @@ type objectMetadataCmd struct {
 }
 
 func (o *objectMetadataCmd) Run(kongCtx *kong.Context) error {
-	objectStoreClient := objectStoreClient(o.BaseURL, o.LatticeVMToken, o.LatticeEnvToken, nil)
+	objectStoreClient := objectStoreClient(o.BaseURL, o.EnvironmentToken, o.SandboxesToken, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -126,7 +126,7 @@ type getCmd struct {
 }
 
 func (o *getCmd) Run(kongCtx *kong.Context) error {
-	objectStoreClient := objectStoreClient(o.BaseURL, o.LatticeVMToken, o.LatticeEnvToken, nil)
+	objectStoreClient := objectStoreClient(o.BaseURL, o.EnvironmentToken, o.SandboxesToken, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -157,7 +157,7 @@ type listCmd struct {
 }
 
 func (l *listCmd) Run(kongCtx *kong.Context) error {
-	objectStoreClient := objectStoreClient(l.BaseURL, l.LatticeVMToken, l.LatticeEnvToken, nil)
+	objectStoreClient := objectStoreClient(l.BaseURL, l.EnvironmentToken, l.SandboxesToken, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -195,13 +195,13 @@ func pathMetadataStr(pathMetadata *api.PathMetadata) (string, error) {
 
 func objectStoreClient(
 	url string,
-	vmToken string,
-	latticeToken string,
+	environmentToken string,
+	sandboxesToken string,
 	additionalHeaders http.Header,
 ) *client.Client {
 	header := http.Header{}
-	header.Add("authorization", fmt.Sprintf("Bearer %s", vmToken))
-	header.Add("anduril-sandbox-authorization", fmt.Sprintf("Bearer %s", latticeToken))
+	header.Add("authorization", fmt.Sprintf("Bearer %s", environmentToken))
+	header.Add("anduril-sandbox-authorization", fmt.Sprintf("Bearer %s", sandboxesToken))
 
 	for headerKey, headerValues := range additionalHeaders {
 		for _, headerValue := range headerValues {
@@ -216,7 +216,7 @@ func objectStoreClient(
 }
 
 type connectionOpts struct {
-	BaseURL         string `short:"b" name:"base-url"          required:""`
-	LatticeVMToken  string `short:"v" name:"lattice-vm-token"  required:""`
-	LatticeEnvToken string `short:"e" name:"lattice-env-token" required:""`
+	BaseURL          string `short:"b" name:"base-url"          required:""`
+	EnvironmentToken string `short:"v" name:"environment-token" required:""`
+	SandboxesToken   string `short:"e" name:"sandboxes-token"   required:""`
 }

--- a/readme.md
+++ b/readme.md
@@ -37,8 +37,10 @@ $ go run main.go <command> [flags]
 Every command requires the following connection options:
 
 - **-b, --base-url**: Base URL for the object store service.
-- **-v, --lattice-vm-token**: Lattice VM authorization token.
-- **-e, --lattice-env-token**: Lattice environment token.
+- **-v, --environment-token**: Lattice environment token.
+- **-e, --sandboxes-token**: Lattice sandboxes token.
+
+For information on how to obtain these tokens, see the [Sandboxes documentation](https://developer.anduril.com/guides/getting-started/sandboxes#get-the-tokens).
 
 The CLI supports five subcommands: **delete**, **upload**, **object-metadata**, **get**, and **list**.
 
@@ -50,12 +52,12 @@ Remove a file or object from the object store.
 
 Usage:
 ```
-$ sample-app-objects delete -b <base-url> -v <lattice-vm-token> -e <lattice-env-token> -p <path>
+$ sample-app-objects delete -b <base-url> -v <environment-token> -e <sandboxes-token> -p <path>
 ```
 
 Example:
 ```
-$ sample-app-objects delete -b lattice-00000.env.sandboxes.developer.anduril.com -v my-vm-token -e my-env-token -p some/path/to/object
+$ sample-app-objects delete -b lattice-00000.env.sandboxes.developer.anduril.com -v my-environment-token -e my-sandboxes-token -p some/path/to/object
 ```
 
 #### Upload
@@ -64,11 +66,11 @@ Upload a file to the object store. Optionally, specify a TTL (time-to-live) for 
 
 Usage:
 ```
-$ sample-app-objects upload -b <base-url> -v <lattice-vm-token> -e <lattice-env-token> -i <input-file-path> -p <object-store-path> [-t <time-to-live>]
+$ sample-app-objects upload -b <base-url> -v <environment-token> -e <sandboxes-token> -i <input-file-path> -p <object-store-path> [-t <time-to-live>]
 ```
 Example:
 ```
-$ sample-app-objects upload -b lattice-00000.env.sandboxes.developer.anduril.com -v my-vm-token -e my-env-token -i ./localfile.txt -p object/file.txt -t 2h
+$ sample-app-objects upload -b lattice-00000.env.sandboxes.developer.anduril.com -v my-environment-token -e my-sandboxes-token -i ./localfile.txt -p object/file.txt -t 2h
 ```
 
 > The `-t` flag accepts duration strings (e.g., "2h", "30m").
@@ -79,12 +81,12 @@ Retrieve metadata for a specific object.
 
 Usage:
 ```
-$ sample-app-objects object-metadata -b <base-url> -v <lattice-vm-token> -e <lattice-env-token> -p <path>
+$ sample-app-objects object-metadata -b <base-url> -v <environment-token> -e <sandboxes-token> -p <path>
 ```
 
 Example:
 ```
-$ sample-app-objects object-metadata -b lattice-00000.env.sandboxes.developer.anduril.com -v my-vm-token -e my-env-token -p my-prefix/file.txt
+$ sample-app-objects object-metadata -b lattice-00000.env.sandboxes.developer.anduril.com -v my-environment-token -e my-sandboxes-token -p my-prefix/file.txt
 ```
 
 #### Get
@@ -93,7 +95,7 @@ Download an object from the store and save it to a local file.
 
 Usage:
 ```
-$ sample-app-objects get -b <base-url> -v <lattice-vm-token> -e <lattice-env-token> -p <object-store-path> -o <output-file-path> [-r]
+$ sample-app-objects get -b <base-url> -v <environment-token> -e <sandboxes-token> -p <object-store-path> -o <output-file-path> [-r]
 ```
 
 - **-p, --object-store-path**: Path in the object store to download.
@@ -102,7 +104,7 @@ $ sample-app-objects get -b <base-url> -v <lattice-vm-token> -e <lattice-env-tok
 
 Example:
 ```
-$ sample-app-objects get -b lattice-00000.env.sandboxes.developer.anduril.com -v my-vm-token -e my-env-token -p my-prefix/file.txt -o ./downloaded.txt
+$ sample-app-objects get -b lattice-00000.env.sandboxes.developer.anduril.com -v my-environment-token -e my-sandboxes-token -p my-prefix/file.txt -o ./downloaded.txt
 ```
 
 #### List
@@ -111,7 +113,7 @@ List objects stored in the object store. Optionally filter results by a prefix.
 
 Usage:
 ```
-$ sample-app-objects list -b <base-url> -v <lattice-vm-token> -e <lattice-env-token> [prefix]
+$ sample-app-objects list -b <base-url> -v <environment-token> -e <sandboxes-token> [prefix]
 ```
 
 If a prefix is provided, only objects with that prefix will be listed.
@@ -119,5 +121,5 @@ If a prefix is provided, only objects with that prefix will be listed.
 Example:
 
 ```
-$ sample-app-objects list -b lattice-00000.env.sandboxes.developer.anduril.com -v my-vm-token -e my-env-token my/prefix
+$ sample-app-objects list -b lattice-00000.env.sandboxes.developer.anduril.com -v my-environment-token -e my-sandboxes-token my/prefix
 ```


### PR DESCRIPTION
Updated the token naming in the code to be consistent with the README and other sample applications. Changed:
1.  to 
2.  to 
3. Updated all function calls to use the new field names

This change ensures consistency in terminology across all sample applications.